### PR TITLE
:arrow_up: update: upgrade ruff pre-commit to 0.4.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.4.3
     hooks:
     -   id: ruff
         args:


### PR DESCRIPTION
- Sync version ruff pre-commit with [requirements-tests.txt](https://github.com/tiangolo/fastapi-cli/blob/main/requirements-tests.txt)
- version ruff pre-commit 0.4.3