### PR TITLE
✨ Add support for apps created by factory functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.4.9
     hooks:
     -   id: ruff
         args:

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -62,7 +62,7 @@ def _run(
     proxy_headers: bool = False,
 ) -> None:
     try:
-        use_uvicorn_app = get_import_string(path=path, app_name=app)
+        use_uvicorn_app, is_factory = get_import_string(path=path, app_name=app)
     except FastAPICLIException as e:
         logger.error(str(e))
         raise typer.Exit(code=1) from None
@@ -97,6 +97,7 @@ def _run(
         workers=workers,
         root_path=root_path,
         proxy_headers=proxy_headers,
+        factory=is_factory,
     )
 
 

--- a/src/fastapi_cli/discover.py
+++ b/src/fastapi_cli/discover.py
@@ -3,7 +3,7 @@ import sys
 from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Callable, Union, get_type_hints
+from typing import Any, Callable, Tuple, Union, get_type_hints
 
 from rich import print
 from rich.padding import Padding
@@ -100,7 +100,7 @@ def get_module_data_from_path(path: Path) -> ModuleData:
 
 def get_app_name(
     *, mod_data: ModuleData, app_name: Union[str, None] = None
-) -> tuple[str, bool]:
+) -> Tuple[str, bool]:
     try:
         mod = importlib.import_module(mod_data.module_import_str)
     except (ImportError, ValueError) as e:
@@ -154,7 +154,7 @@ def check_factory(fn: Callable[[], Any]) -> bool:
 
 def get_import_string(
     *, path: Union[Path, None] = None, app_name: Union[str, None] = None
-) -> tuple[str, bool]:
+) -> Tuple[str, bool]:
     if not path:
         path = get_default_path()
     logger.info(f"Using path [blue]{path}[/blue]")

--- a/src/fastapi_cli/discover.py
+++ b/src/fastapi_cli/discover.py
@@ -145,8 +145,6 @@ def get_app_name(
 
 def check_factory(fn: Callable[[], Any]) -> bool:
     """Checks whether the return-type of a factory function is FastAPI"""
-    # if not callable(fn):
-    #    return False
     type_hints = get_type_hints(fn)
     return_type = type_hints.get("return")
     return return_type is not None and issubclass(return_type, FastAPI)

--- a/tests/assets/factory_create_api.py
+++ b/tests/assets/factory_create_api.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+
+def create_api() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    def app_root():
+        return {"message": "single file factory app"}
+
+    return app

--- a/tests/assets/factory_create_app.py
+++ b/tests/assets/factory_create_app.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+
+
+class App(FastAPI): ...
+
+
+def create_app_other() -> App:
+    app = App()
+
+    @app.get("/")
+    def app_root():
+        return {"message": "single file factory app inherited"}
+
+    return app
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    def app_root():
+        return {"message": "single file factory app"}
+
+    return app

--- a/tests/assets/factory_create_app.py
+++ b/tests/assets/factory_create_app.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
 
 
-class App(FastAPI): ...
+class App(FastAPI):
+    ...
 
 
 def create_app_other() -> App:

--- a/tests/assets/factory_create_app.py
+++ b/tests/assets/factory_create_app.py
@@ -1,8 +1,7 @@
 from fastapi import FastAPI
 
 
-class App(FastAPI):
-    ...
+class App(FastAPI): ...
 
 
 def create_app_other() -> App:

--- a/tests/assets/package/mod/factory_api.py
+++ b/tests/assets/package/mod/factory_api.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+
+def create_api() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    def root():
+        return {"message": "package create_api"}
+
+    return app

--- a/tests/assets/package/mod/factory_app.py
+++ b/tests/assets/package/mod/factory_app.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    def root():
+        return {"message": "package create_app"}
+
+    return app

--- a/tests/assets/package/mod/factory_inherit.py
+++ b/tests/assets/package/mod/factory_inherit.py
@@ -1,8 +1,7 @@
 from fastapi import FastAPI
 
 
-class App(FastAPI):
-    ...
+class App(FastAPI): ...
 
 
 def create_app() -> App:

--- a/tests/assets/package/mod/factory_inherit.py
+++ b/tests/assets/package/mod/factory_inherit.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
 
 
-class App(FastAPI): ...
+class App(FastAPI):
+    ...
 
 
 def create_app() -> App:

--- a/tests/assets/package/mod/factory_inherit.py
+++ b/tests/assets/package/mod/factory_inherit.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+
+class App(FastAPI): ...
+
+
+def create_app() -> App:
+    app = App()
+
+    @app.get("/")
+    def root():
+        return {"message": "package build_app"}
+
+    return app

--- a/tests/assets/package/mod/factory_other.py
+++ b/tests/assets/package/mod/factory_other.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    def root():
+        return {"message": "package build_app"}
+
+    return app

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,8 +29,36 @@ def test_dev() -> None:
                 "workers": None,
                 "root_path": "",
                 "proxy_headers": True,
+                "factory": False,
             }
         assert "Using import string single_file_app:app" in result.output
+        assert (
+            "╭────────── FastAPI CLI - Development mode ───────────╮" in result.output
+        )
+        assert "│  Serving at: http://127.0.0.1:8000" in result.output
+        assert "│  API docs: http://127.0.0.1:8000/docs" in result.output
+        assert "│  Running in development mode, for production use:" in result.output
+        assert "│  fastapi run" in result.output
+
+
+def test_dev_factory() -> None:
+    with changing_dir(assets_path):
+        with patch.object(uvicorn, "run") as mock_run:
+            result = runner.invoke(app, ["dev", "factory_create_app.py"])
+            assert result.exit_code == 0, result.output
+            assert mock_run.called
+            assert mock_run.call_args
+            assert mock_run.call_args.kwargs == {
+                "app": "factory_create_app:create_app",
+                "host": "127.0.0.1",
+                "port": 8000,
+                "reload": True,
+                "workers": None,
+                "root_path": "",
+                "proxy_headers": True,
+                "factory": True,
+            }
+        assert "Using import string factory_create_app:create_app" in result.output
         assert (
             "╭────────── FastAPI CLI - Development mode ───────────╮" in result.output
         )
@@ -71,6 +99,7 @@ def test_dev_args() -> None:
                 "workers": None,
                 "root_path": "/api",
                 "proxy_headers": False,
+                "factory": False,
             }
         assert "Using import string single_file_app:api" in result.output
         assert (
@@ -97,8 +126,36 @@ def test_run() -> None:
                 "workers": None,
                 "root_path": "",
                 "proxy_headers": True,
+                "factory": False,
             }
         assert "Using import string single_file_app:app" in result.output
+        assert (
+            "╭─────────── FastAPI CLI - Production mode ───────────╮" in result.output
+        )
+        assert "│  Serving at: http://0.0.0.0:8000" in result.output
+        assert "│  API docs: http://0.0.0.0:8000/docs" in result.output
+        assert "│  Running in production mode, for development use:" in result.output
+        assert "│  fastapi dev" in result.output
+
+
+def test_run_factory() -> None:
+    with changing_dir(assets_path):
+        with patch.object(uvicorn, "run") as mock_run:
+            result = runner.invoke(app, ["run", "factory_create_app.py"])
+            assert result.exit_code == 0, result.output
+            assert mock_run.called
+            assert mock_run.call_args
+            assert mock_run.call_args.kwargs == {
+                "app": "factory_create_app:create_app",
+                "host": "0.0.0.0",
+                "port": 8000,
+                "reload": False,
+                "workers": None,
+                "root_path": "",
+                "proxy_headers": True,
+                "factory": True,
+            }
+        assert "Using import string factory_create_app:create_app" in result.output
         assert (
             "╭─────────── FastAPI CLI - Production mode ───────────╮" in result.output
         )
@@ -141,6 +198,7 @@ def test_run_args() -> None:
                 "workers": 2,
                 "root_path": "/api",
                 "proxy_headers": False,
+                "factory": False,
             }
         assert "Using import string single_file_app:api" in result.output
         assert (

--- a/tests/test_utils_check_factory.py
+++ b/tests/test_utils_check_factory.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from fastapi_cli.discover import check_factory
+
+
+def test_check_untyped_factory() -> None:
+    def create_app():  # type: ignore[no-untyped-def]
+        return FastAPI()  # pragma: no cover
+
+    assert check_factory(create_app) is False
+
+
+def test_check_typed_factory() -> None:
+    def create_app() -> FastAPI:
+        return FastAPI()  # pragma: no cover
+
+    assert check_factory(create_app) is True
+
+
+def test_check_typed_factory_inherited() -> None:
+    class MyApp(FastAPI): ...
+
+    def create_app() -> MyApp:
+        return MyApp()  # pragma: no cover
+
+    assert check_factory(create_app) is True
+
+
+def test_create_app_with_different_type() -> None:
+    def create_app() -> int:
+        return 1  # pragma: no cover
+
+    assert check_factory(create_app) is False

--- a/tests/test_utils_check_factory.py
+++ b/tests/test_utils_check_factory.py
@@ -17,8 +17,7 @@ def test_check_typed_factory() -> None:
 
 
 def test_check_typed_factory_inherited() -> None:
-    class MyApp(FastAPI):
-        ...
+    class MyApp(FastAPI): ...
 
     def create_app() -> MyApp:
         return MyApp()  # pragma: no cover

--- a/tests/test_utils_check_factory.py
+++ b/tests/test_utils_check_factory.py
@@ -17,7 +17,8 @@ def test_check_typed_factory() -> None:
 
 
 def test_check_typed_factory_inherited() -> None:
-    class MyApp(FastAPI): ...
+    class MyApp(FastAPI):
+        ...
 
     def create_app() -> MyApp:
         return MyApp()  # pragma: no cover

--- a/tests/test_utils_default_dir.py
+++ b/tests/test_utils_default_dir.py
@@ -12,8 +12,9 @@ assets_path = Path(__file__).parent / "assets"
 
 def test_app_dir_main(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "default_files" / "default_app_dir_main"):
-        import_string = get_import_string()
+        import_string, is_factory = get_import_string()
         assert import_string == "app.main:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path app/main.py" in captured.out
@@ -36,8 +37,9 @@ def test_app_dir_main(capsys: CaptureFixture[str]) -> None:
 
 def test_app_dir_app(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "default_files" / "default_app_dir_app"):
-        import_string = get_import_string()
+        import_string, is_factory = get_import_string()
         assert import_string == "app.app:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path app/app.py" in captured.out
@@ -58,8 +60,9 @@ def test_app_dir_app(capsys: CaptureFixture[str]) -> None:
 
 def test_app_dir_api(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "default_files" / "default_app_dir_api"):
-        import_string = get_import_string()
+        import_string, is_factory = get_import_string()
         assert import_string == "app.api:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path app/api.py" in captured.out

--- a/tests/test_utils_default_file.py
+++ b/tests/test_utils_default_file.py
@@ -20,8 +20,9 @@ def test_single_file_main(capsys: CaptureFixture[str]) -> None:
         mod = importlib.import_module("main")
 
         importlib.reload(mod)
-        import_string = get_import_string()
+        import_string, is_factory = get_import_string()
         assert import_string == "main:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path main.py" in captured.out
@@ -47,8 +48,9 @@ def test_single_file_app(capsys: CaptureFixture[str]) -> None:
         mod = importlib.import_module("app")
 
         importlib.reload(mod)
-        import_string = get_import_string()
+        import_string, is_factory = get_import_string()
         assert import_string == "app:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path app.py" in captured.out
@@ -74,8 +76,9 @@ def test_single_file_api(capsys: CaptureFixture[str]) -> None:
         mod = importlib.import_module("api")
 
         importlib.reload(mod)
-        import_string = get_import_string()
+        import_string, is_factory = get_import_string()
         assert import_string == "api:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path api.py" in captured.out

--- a/tests/test_utils_package.py
+++ b/tests/test_utils_package.py
@@ -12,8 +12,9 @@ assets_path = Path(__file__).parent / "assets"
 
 def test_package_app_root(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("package/mod/app.py"))
+        import_string, is_factory = get_import_string(path=Path("package/mod/app.py"))
         assert import_string == "package.mod.app:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path package/mod/app.py" in captured.out
@@ -40,8 +41,9 @@ def test_package_app_root(capsys: CaptureFixture[str]) -> None:
 
 def test_package_api_root(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("package/mod/api.py"))
+        import_string, is_factory = get_import_string(path=Path("package/mod/api.py"))
         assert import_string == "package.mod.api:api"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path package/mod/api.py" in captured.out
@@ -68,8 +70,9 @@ def test_package_api_root(capsys: CaptureFixture[str]) -> None:
 
 def test_package_other_root(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("package/mod/other.py"))
+        import_string, is_factory = get_import_string(path=Path("package/mod/other.py"))
         assert import_string == "package.mod.other:first_other"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path package/mod/other.py" in captured.out
@@ -94,10 +97,135 @@ def test_package_other_root(capsys: CaptureFixture[str]) -> None:
     assert "Using import string package.mod.other:first_other" in captured.out
 
 
+def test_package_factory_app_root(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("package/mod/factory_app.py")
+        )
+        assert import_string == "package.mod.factory_app:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path package/mod/factory_app.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_app.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_app.py" in captured.out
+    assert "Importing module package.mod.factory_app" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_app import create_app" in captured.out
+    assert "Using import string package.mod.factory_app:create_app" in captured.out
+
+
+def test_package_factory_api_root(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("package/mod/factory_api.py")
+        )
+        assert import_string == "package.mod.factory_api:create_api"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path package/mod/factory_api.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_api.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_api.py" in captured.out
+    assert "Importing module package.mod.factory_api" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_api import create_api" in captured.out
+    assert "Using import string package.mod.factory_api:create_api" in captured.out
+
+
+def test_package_factory_other_root(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("package/mod/factory_other.py"), app_name="build_app"
+        )
+        assert import_string == "package.mod.factory_other:build_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path package/mod/factory_other.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_other.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_other.py" in captured.out
+    assert "Importing module package.mod.factory_other" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_other import build_app" in captured.out
+    assert "Using import string package.mod.factory_other:build_app" in captured.out
+
+
+def test_package_factory_inherit_root(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("package/mod/factory_inherit.py")
+        )
+        assert import_string == "package.mod.factory_inherit:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path package/mod/factory_inherit.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_inherit.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_inherit.py" in captured.out
+    assert "Importing module package.mod.factory_inherit" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_inherit import create_app" in captured.out
+    assert "Using import string package.mod.factory_inherit:create_app" in captured.out
+
+
 def test_package_app_mod(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "package/mod"):
-        import_string = get_import_string(path=Path("app.py"))
+        import_string, is_factory = get_import_string(path=Path("app.py"))
         assert import_string == "package.mod.app:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path app.py" in captured.out
@@ -124,8 +252,9 @@ def test_package_app_mod(capsys: CaptureFixture[str]) -> None:
 
 def test_package_api_mod(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "package/mod"):
-        import_string = get_import_string(path=Path("api.py"))
+        import_string, is_factory = get_import_string(path=Path("api.py"))
         assert import_string == "package.mod.api:api"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path api.py" in captured.out
@@ -152,8 +281,9 @@ def test_package_api_mod(capsys: CaptureFixture[str]) -> None:
 
 def test_package_other_mod(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "package/mod"):
-        import_string = get_import_string(path=Path("other.py"))
+        import_string, is_factory = get_import_string(path=Path("other.py"))
         assert import_string == "package.mod.other:first_other"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path other.py" in captured.out
@@ -178,10 +308,131 @@ def test_package_other_mod(capsys: CaptureFixture[str]) -> None:
     assert "Using import string package.mod.other:first_other" in captured.out
 
 
-def test_package_app_above(capsys: CaptureFixture[str]) -> None:
+def test_package_factory_app_mod(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path / "package/mod"):
+        import_string, is_factory = get_import_string(path=Path("factory_app.py"))
+        assert import_string == "package.mod.factory_app:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_app.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_app.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_app.py" in captured.out
+    assert "Importing module package.mod.factory_app" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_app import create_app" in captured.out
+    assert "Using import string package.mod.factory_app:create_app" in captured.out
+
+
+def test_package_factory_api_mod(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path / "package/mod"):
+        import_string, is_factory = get_import_string(path=Path("factory_api.py"))
+        assert import_string == "package.mod.factory_api:create_api"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_api.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_api.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_api.py" in captured.out
+    assert "Importing module package.mod.factory_api" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_api import create_api" in captured.out
+    assert "Using import string package.mod.factory_api:create_api" in captured.out
+
+
+def test_package_factory_other_mod(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path / "package/mod"):
+        import_string, is_factory = get_import_string(
+            path=Path("factory_other.py"), app_name="build_app"
+        )
+        assert import_string == "package.mod.factory_other:build_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_other.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_other.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_other.py" in captured.out
+    assert "Importing module package.mod.factory_other" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_other import build_app" in captured.out
+    assert "Using import string package.mod.factory_other:build_app" in captured.out
+
+
+def test_package_factory_inherit_mod(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path / "package/mod"):
+        import_string, is_factory = get_import_string(path=Path("factory_inherit.py"))
+        assert import_string == "package.mod.factory_inherit:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_inherit.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_inherit.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_inherit.py" in captured.out
+    assert "Importing module package.mod.factory_inherit" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_inherit import create_app" in captured.out
+    assert "Using import string package.mod.factory_inherit:create_app" in captured.out
+
+
+def test_package_app_parent(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path.parent):
-        import_string = get_import_string(path=Path("assets/package/mod/app.py"))
+        import_string, is_factory = get_import_string(
+            path=Path("assets/package/mod/app.py")
+        )
         assert import_string == "package.mod.app:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path assets/package/mod/app.py" in captured.out
@@ -208,8 +459,11 @@ def test_package_app_above(capsys: CaptureFixture[str]) -> None:
 
 def test_package_api_parent(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path.parent):
-        import_string = get_import_string(path=Path("assets/package/mod/api.py"))
+        import_string, is_factory = get_import_string(
+            path=Path("assets/package/mod/api.py")
+        )
         assert import_string == "package.mod.api:api"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path assets/package/mod/api.py" in captured.out
@@ -236,8 +490,11 @@ def test_package_api_parent(capsys: CaptureFixture[str]) -> None:
 
 def test_package_other_parent(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path.parent):
-        import_string = get_import_string(path=Path("assets/package/mod/other.py"))
+        import_string, is_factory = get_import_string(
+            path=Path("assets/package/mod/other.py")
+        )
         assert import_string == "package.mod.other:first_other"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path assets/package/mod/other.py" in captured.out
@@ -262,10 +519,136 @@ def test_package_other_parent(capsys: CaptureFixture[str]) -> None:
     assert "Using import string package.mod.other:first_other" in captured.out
 
 
+def test_package_factory_app_parent(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path.parent):
+        import_string, is_factory = get_import_string(
+            path=Path("assets/package/mod/factory_app.py")
+        )
+        assert import_string == "package.mod.factory_app:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path assets/package/mod/factory_app.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_app.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_app.py" in captured.out
+    assert "Importing module package.mod.factory_app" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_app import create_app" in captured.out
+    assert "Using import string package.mod.factory_app:create_app" in captured.out
+
+
+def test_package_factory_api_parent(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path.parent):
+        import_string, is_factory = get_import_string(
+            path=Path("assets/package/mod/factory_api.py")
+        )
+        assert import_string == "package.mod.factory_api:create_api"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path assets/package/mod/factory_api.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_api.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_api.py" in captured.out
+    assert "Importing module package.mod.factory_api" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_api import create_api" in captured.out
+    assert "Using import string package.mod.factory_api:create_api" in captured.out
+
+
+def test_package_factory_other_parent(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path.parent):
+        import_string, is_factory = get_import_string(
+            path=Path("assets/package/mod/factory_other.py"),
+            app_name="build_app",
+        )
+        assert import_string == "package.mod.factory_other:build_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path assets/package/mod/factory_other.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_other.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_other.py" in captured.out
+    assert "Importing module package.mod.factory_other" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_other import build_app" in captured.out
+    assert "Using import string package.mod.factory_other:build_app" in captured.out
+
+
+def test_package_factory_inherit_parent(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path.parent):
+        import_string, is_factory = get_import_string(
+            path=Path("assets/package/mod/factory_inherit.py")
+        )
+        assert import_string == "package.mod.factory_inherit:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path assets/package/mod/factory_inherit.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/package/mod/factory_inherit.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭─ Python package file structure ─╮" in captured.out
+    assert "│  📁 package" in captured.out
+    assert "│  ├── 🐍 __init__.py" in captured.out
+    assert "│  └── 📁 mod" in captured.out
+    assert "│      ├── 🐍 __init__.py " in captured.out
+    assert "│      └── 🐍 factory_inherit.py" in captured.out
+    assert "Importing module package.mod.factory_inherit" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from package.mod.factory_inherit import create_app" in captured.out
+    assert "Using import string package.mod.factory_inherit:create_app" in captured.out
+
+
 def test_package_mod_init_inside(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "package/mod"):
-        import_string = get_import_string(path=Path("__init__.py"))
+        import_string, is_factory = get_import_string(path=Path("__init__.py"))
         assert import_string == "package.mod:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path __init__.py" in captured.out
@@ -291,8 +674,9 @@ def test_package_mod_init_inside(capsys: CaptureFixture[str]) -> None:
 
 def test_package_mod_dir(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("package/mod"))
+        import_string, is_factory = get_import_string(path=Path("package/mod"))
         assert import_string == "package.mod:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path package/mod" in captured.out
@@ -318,8 +702,9 @@ def test_package_mod_dir(capsys: CaptureFixture[str]) -> None:
 
 def test_package_init_inside(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "package"):
-        import_string = get_import_string(path=Path("__init__.py"))
+        import_string, is_factory = get_import_string(path=Path("__init__.py"))
         assert import_string == "package:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path __init__.py" in captured.out
@@ -343,8 +728,9 @@ def test_package_init_inside(capsys: CaptureFixture[str]) -> None:
 
 def test_package_dir_inside_package(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path / "package/mod"):
-        import_string = get_import_string(path=Path("../"))
+        import_string, is_factory = get_import_string(path=Path("../"))
         assert import_string == "package:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path .." in captured.out
@@ -368,8 +754,9 @@ def test_package_dir_inside_package(capsys: CaptureFixture[str]) -> None:
 
 def test_package_dir_above_package(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path.parent):
-        import_string = get_import_string(path=Path("assets/package"))
+        import_string, is_factory = get_import_string(path=Path("assets/package"))
         assert import_string == "package:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path assets/package" in captured.out
@@ -393,8 +780,11 @@ def test_package_dir_above_package(capsys: CaptureFixture[str]) -> None:
 
 def test_package_dir_explicit_app(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("package"), app_name="api")
+        import_string, is_factory = get_import_string(
+            path=Path("package"), app_name="api"
+        )
         assert import_string == "package:api"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path package" in captured.out

--- a/tests/test_utils_single_file.py
+++ b/tests/test_utils_single_file.py
@@ -12,8 +12,9 @@ assets_path = Path(__file__).parent / "assets"
 
 def test_single_file_app(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("single_file_app.py"))
+        import_string, is_factory = get_import_string(path=Path("single_file_app.py"))
         assert import_string == "single_file_app:app"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path single_file_app.py" in captured.out
@@ -36,8 +37,9 @@ def test_single_file_app(capsys: CaptureFixture[str]) -> None:
 
 def test_single_file_api(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("single_file_api.py"))
+        import_string, is_factory = get_import_string(path=Path("single_file_api.py"))
         assert import_string == "single_file_api:api"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path single_file_api.py" in captured.out
@@ -60,8 +62,9 @@ def test_single_file_api(capsys: CaptureFixture[str]) -> None:
 
 def test_single_file_other(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(path=Path("single_file_other.py"))
+        import_string, is_factory = get_import_string(path=Path("single_file_other.py"))
         assert import_string == "single_file_other:first_other"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path single_file_other.py" in captured.out
@@ -84,10 +87,11 @@ def test_single_file_other(capsys: CaptureFixture[str]) -> None:
 
 def test_single_file_explicit_object(capsys: CaptureFixture[str]) -> None:
     with changing_dir(assets_path):
-        import_string = get_import_string(
+        import_string, is_factory = get_import_string(
             path=Path("single_file_app.py"), app_name="second_other"
         )
         assert import_string == "single_file_app:second_other"
+        assert is_factory is False
 
     captured = capsys.readouterr()
     assert "Using path single_file_app.py" in captured.out
@@ -106,6 +110,116 @@ def test_single_file_explicit_object(capsys: CaptureFixture[str]) -> None:
     assert "Importable FastAPI app" in captured.out
     assert "from single_file_app import second_other" in captured.out
     assert "Using import string single_file_app:second_other" in captured.out
+
+
+def test_single_file_create_app_factory_function(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("factory_create_app.py")
+        )
+        assert import_string == "factory_create_app:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_create_app.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/factory_create_app.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭──── Python module file ────╮" in captured.out
+    assert "│  🐍 factory_create_app.py" in captured.out
+    assert "Importing module factory_create_app" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from factory_create_app import create_app" in captured.out
+    assert "Using import string factory_create_app:create_app" in captured.out
+
+
+def test_single_file_create_api_factory_function(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("factory_create_api.py")
+        )
+        assert import_string == "factory_create_api:create_api"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_create_api.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/factory_create_api.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭──── Python module file ────╮" in captured.out
+    assert "│  🐍 factory_create_api.py" in captured.out
+    assert "Importing module factory_create_api" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from factory_create_api import create_api" in captured.out
+    assert "Using import string factory_create_api:create_api" in captured.out
+
+
+def test_single_file_explicit_factory_function(capsys: CaptureFixture[str]) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("factory_create_app.py"), app_name="create_app"
+        )
+        assert import_string == "factory_create_app:create_app"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_create_app.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/factory_create_app.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭──── Python module file ────╮" in captured.out
+    assert "│  🐍 factory_create_app.py" in captured.out
+    assert "Importing module factory_create_app" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from factory_create_app import create_app" in captured.out
+    assert "Using import string factory_create_app:create_app" in captured.out
+
+
+def test_single_file_explicit_factory_function_other(
+    capsys: CaptureFixture[str],
+) -> None:
+    with changing_dir(assets_path):
+        import_string, is_factory = get_import_string(
+            path=Path("factory_create_app.py"), app_name="create_app_other"
+        )
+        assert import_string == "factory_create_app:create_app_other"
+        assert is_factory is True
+
+    captured = capsys.readouterr()
+    assert "Using path factory_create_app.py" in captured.out
+    assert "Resolved absolute path" in captured.out
+    assert "tests/assets/factory_create_app.py" in captured.out
+    assert (
+        "Searching for package file structure from directories with __init__.py files"
+        in captured.out
+    )
+    assert "Importing from" in captured.out
+    assert "tests/assets" in captured.out
+    assert "╭──── Python module file ────╮" in captured.out
+    assert "│  🐍 factory_create_app.py" in captured.out
+    assert "Importing module factory_create_app" in captured.out
+    assert "Found importable FastAPI app" in captured.out
+    assert "Importable FastAPI app" in captured.out
+    assert "from factory_create_app import create_app_other" in captured.out
+    assert "Using import string factory_create_app:create_app_other" in captured.out
 
 
 def test_single_non_existing_file() -> None:


### PR DESCRIPTION
This change adds support for using return-typed factory functions, as well as auto-detecting some function names.

I've identified factory functions by inspecting the return-type of the function (`def create_app() -> FastAPI`). This does require the function to be typed, but that seemed preferable to calling the function and booting the app.

I've added two default factory-function names to auto-detect: `create_app()` and `create_api()`. I've seen `create_app` in use in the GH issues, and added `create_api` to match the existing default names. These work in the same way as the other auto-detection. You can of course pass your own function name with `fastapi run --app=build_app`.

I decided not to copy the first-FastAPI-instance-found behaviour, as I've worked on a project before that had multiple app factories in a single file for different use-cases. One example could be a second factory that enables the debug option.

In order to pass the `--factory` argument to uvicorn, I changed the return signature of `get_import_string()` to return a `tuple[str, bool]` of import-string, and whether the object is a factory function or not. Unfortunately this is a breaking change if this function is used externally. We could import that object again and check it if that's an issue.

In keeping with the other tests, I opted not to use `@pytest.mark.parametrize` to fill in the package/factory dynamically - but if you're happy with that I'd like to refactor to use that (and reduce 1k lines 🙂).

---

FYI pre-commit was fighting with my local ruff from requirements-dev.lock - bumping the ruff hook version seemed to fix it (89ac14b).

Thanks again for FastAPI!