### PR TITLE
♻️ Add `fastapi-cli[standard]` including Uvicorn, make `fastapi-cli` and `fastapi-cli-slim` have the same packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run and manage FastAPI apps from the command line with FastAPI CLI. 🚀
 
 **FastAPI CLI** is a command line program `fastapi` that you can use to serve your FastAPI app, manage your FastAPI project, and more.
 
-When you install FastAPI (e.g. with `pip install fastapi`), it includes a package called `fastapi-cli`, this package provides the `fastapi` command in the terminal.
+When you install FastAPI (e.g. with `pip install "fastapi[standard]"`), it includes a package called `fastapi-cli`, this package provides the `fastapi` command in the terminal.
 
 To run your FastAPI app for development, you can use the `fastapi dev` command:
 

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from pdm.backend.hooks import Context
 
@@ -11,29 +11,10 @@ def pdm_build_initialize(context: Context):
     # Get custom config for the current package, from the env var
     config: Dict[str, Any] = context.config.data["tool"]["tiangolo"][
         "_internal-slim-build"
-    ]["packages"][TIANGOLO_BUILD_PACKAGE]
+    ]["packages"].get(TIANGOLO_BUILD_PACKAGE)
+    if not config:
+        return
     project_config: Dict[str, Any] = config["project"]
-    # Get main optional dependencies, extras
-    optional_dependencies: Dict[str, List[str]] = metadata.get(
-        "optional-dependencies", {}
-    )
-    # Get custom optional dependencies name to always include in this (non-slim) package
-    include_optional_dependencies: List[str] = config.get(
-        "include-optional-dependencies", []
-    )
     # Override main [project] configs with custom configs for this package
     for key, value in project_config.items():
         metadata[key] = value
-    # Get custom build config for the current package
-    build_config: Dict[str, Any] = (
-        config.get("tool", {}).get("pdm", {}).get("build", {})
-    )
-    # Override PDM build config with custom build config for this package
-    for key, value in build_config.items():
-        context.config.build_config[key] = value
-    # Get main dependencies
-    dependencies: List[str] = metadata.get("dependencies", [])
-    # Add optional dependencies to the default dependencies for this (non-slim) package
-    for include_optional in include_optional_dependencies:
-        optional_dependencies_group = optional_dependencies.get(include_optional, [])
-        dependencies.extend(optional_dependencies_group)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
 
 [project.optional-dependencies]
 standard = [
-    "fastapi",
     "uvicorn[standard] >= 0.15.0",
 ]
 
@@ -68,14 +67,6 @@ source-includes = [
 
 [tool.tiangolo._internal-slim-build.packages.fastapi-cli-slim.project]
 name = "fastapi-cli-slim"
-
-[tool.tiangolo._internal-slim-build.packages.fastapi-cli]
-# No default dependencies included for now
-include-optional-dependencies = []
-
-[tool.tiangolo._internal-slim-build.packages.fastapi-cli.project]
-# No custom optional dependencies for now
-# optional-dependencies = {}
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
♻️ Add `fastapi-cli[standard]` including Uvicorn, make `fastapi-cli` and `fastapi-cli-slim` have the same packages.

## Summary

Install with:

```bash
pip install "fastapi[standard]"
```

Or if for some reason installing only the CLI:

```bash
pip install "fastapi-cli[standard]"
```

## Before

Before this, `fastapi-cli` would include Uvicorn and `fastapi-cli-slim` would not include Uvicorn.

Now `fastapi-cli` doesn't include Uvicorn unless it is installed with `fastapi-cli[standard]`.

There will be a `fastapi[standard]` and that one will include `fastapi-cli[standard]`.

Before you would install `pip install fastapi`, or `pip install fastapi-cli`, now you should include the `standard` optional dependencies (unless you want to exclude one of those).