### PR TITLE
➕ Keep Uvicorn in default dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "typer >= 0.12.3",
+    "uvicorn[standard] >= 0.15.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
➕ Keep Uvicorn in default dependencies

For at least a few releases. In case someone has an old version of `fastapi` that install the latest `fastapi-cli` (but not `fastapi-cli[standard]`), at least for a while it should include the same dependencies as before.