### PR TITLE
💚 Set `include-hidden-files` to `True` when using the `upload-artifact` GH action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage
+          include-hidden-files: true
 
   coverage-combine:
     needs: [test]
@@ -105,6 +106,7 @@ jobs:
         with:
           name: coverage-html
           path: htmlcov
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   check:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
Since `actions/upload-artifact` [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0), hidden files are excluded by default. This PR specifically sets the `include-hidden-files` parameter to `True` to ensure all behaviour remains the same as before.
