### PR TITLE
pyproject.toml: rename fastapi script to fastapi-cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Issues = "https://github.com/fastapi/fastapi-cli/issues"
 Changelog = "https://github.com/fastapi/fastapi-cli/blob/main/release-notes.md"
 
 [project.scripts]
-fastapi = "fastapi_cli.cli:main"
+fastapi-cli = "fastapi_cli.cli:main"
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
The package script started to conflict with fastapi package script since fastapi commit a25c92ce was created. After the both programs were packed in any linux distro and a user tried to install them a file conflict error occured. The simplest way is to rename the script for this python package.