### PR TITLE
🔨 Use ruff check command in format script

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,5 +2,5 @@
 set -x
 set -e
 
-ruff src tests scripts --fix
+ruff check src tests scripts --fix
 ruff format src tests scripts


### PR DESCRIPTION
From ruff [0.5.0](https://github.com/astral-sh/ruff/releases/tag/0.5.0) `ruff <path>` has been removed. Use `ruff check <path>` instead.