### PR TITLE
🐛 Do not disable existing loggers

### DIFF
--- a/src/fastapi_cli/utils/cli.py
+++ b/src/fastapi_cli/utils/cli.py
@@ -18,6 +18,7 @@ class CustomFormatter(DefaultFormatter):
 def get_uvicorn_log_config() -> Dict[str, Any]:
     return {
         "version": 1,
+        "disable_existing_loggers": False,
         "formatters": {
             "default": {
                 "()": CustomFormatter,


### PR DESCRIPTION
The new uvicorn log configuration introduced in https://github.com/fastapi/fastapi-cli/pull/95 and released in [0.0.6](https://github.com/fastapi/fastapi-cli/releases/tag/0.0.6)  disables existing loggers. Therefore, any custom loggers defined in a FastAPI application will no longer work after upgrading to 0.0.6. This is an undocumented breaking change.

This PR returns FastAPI to its previous behavior by not disabling existing loggers.

Here is a minimal reproduction of this issue:

```python
from fastapi import FastAPI

import logging

app = FastAPI()

logging.basicConfig(
    level=logging.INFO,
    format='%(asctime)s - %(levelname)s - %(message)s'
)

logger = logging.getLogger(__name__)

@app.get("/")
def example_endpoint() -> str:
    logger.info("example")
    return "example"
```

Start this app with `fastapi run main.py`.  Visit the endpoint. On 0.0.6, without this PR, the log line is not printed. On 0.0.5, or with this PR, it is.