### PR TITLE
Add server header option to dev and run commands

### DIFF
--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -86,6 +86,7 @@ def _run(
     command: str,
     app: Union[str, None] = None,
     proxy_headers: bool = False,
+    server_header: bool = False,
 ) -> None:
     with get_rich_toolkit() as toolkit:
         server_type = "development" if command == "dev" else "production"
@@ -168,6 +169,7 @@ def _run(
             root_path=root_path,
             proxy_headers=proxy_headers,
             log_config=get_uvicorn_log_config(),
+            server_header=server_header,
         )
 
 
@@ -216,6 +218,10 @@ def dev(
             help="Enable/Disable X-Forwarded-Proto, X-Forwarded-For, X-Forwarded-Port to populate remote address info."
         ),
     ] = True,
+    server_header: Annotated[
+        bool,
+        typer.Option(help="Enable/Disable Server header."),
+    ] = False,
 ) -> Any:
     """
     Run a [bold]FastAPI[/bold] app in [yellow]development[/yellow] mode. 🧪
@@ -251,6 +257,7 @@ def dev(
         app=app,
         command="dev",
         proxy_headers=proxy_headers,
+        server_header=server_header,
     )
 
 
@@ -305,6 +312,10 @@ def run(
             help="Enable/Disable X-Forwarded-Proto, X-Forwarded-For, X-Forwarded-Port to populate remote address info."
         ),
     ] = True,
+    server_header: Annotated[
+        bool,
+        typer.Option(help="Enable/Disable Server header."),
+    ] = False,
 ) -> Any:
     """
     Run a [bold]FastAPI[/bold] app in [green]production[/green] mode. 🚀
@@ -341,6 +352,7 @@ def run(
         app=app,
         command="run",
         proxy_headers=proxy_headers,
+        server_header=server_header,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,7 @@ def test_dev() -> None:
                 "root_path": "",
                 "proxy_headers": True,
                 "log_config": get_uvicorn_log_config(),
+                "server_header": False,
             }
         assert "Using import string: single_file_app:app" in result.output
         assert "Starting development server 🚀" in result.output
@@ -60,6 +61,7 @@ def test_dev_package() -> None:
                 "root_path": "",
                 "proxy_headers": True,
                 "log_config": get_uvicorn_log_config(),
+                "server_header": False,
             }
         assert "Using import string: nested_package.package:app" in result.output
         assert "Starting development server 🚀" in result.output
@@ -94,6 +96,7 @@ def test_dev_args() -> None:
                     "--app",
                     "api",
                     "--no-proxy-headers",
+                    "--server-header",
                 ],
             )
             assert result.exit_code == 0, result.output
@@ -108,6 +111,7 @@ def test_dev_args() -> None:
                 "root_path": "/api",
                 "proxy_headers": False,
                 "log_config": get_uvicorn_log_config(),
+                "server_header": True,
             }
         assert "Using import string: single_file_app:api" in result.output
         assert "Starting development server 🚀" in result.output
@@ -135,6 +139,7 @@ def test_run() -> None:
                 "root_path": "",
                 "proxy_headers": True,
                 "log_config": get_uvicorn_log_config(),
+                "server_header": False,
             }
         assert "Using import string: single_file_app:app" in result.output
         assert "Starting production server 🚀" in result.output
@@ -166,6 +171,7 @@ def test_run_args() -> None:
                     "--app",
                     "api",
                     "--no-proxy-headers",
+                    "--server-header",
                 ],
             )
             assert result.exit_code == 0, result.output
@@ -180,6 +186,7 @@ def test_run_args() -> None:
                 "root_path": "/api",
                 "proxy_headers": False,
                 "log_config": get_uvicorn_log_config(),
+                "server_header": True,
             }
 
         assert "Using import string: single_file_app:api" in result.output


### PR DESCRIPTION
# Security Enhancement: Server Header Control in FastAPI CLI

## Problem Context

Uvicorn, by default, includes the "Server: uvicorn" header in all HTTP responses. This information represents a security risk because:

1. It exposes technical details about the infrastructure (Uvicorn server => Python)
2. It makes it easier for potential attackers to identify the technology being used
3. It can be used to target specific attacks knowing the underlying technology

### Before
<img width="239" alt="image" src="https://github.com/user-attachments/assets/ee54dd17-433c-48d6-82f2-82a6d8888e3d" />

### Now
<img width="200" alt="image" src="https://github.com/user-attachments/assets/0013ed26-3d62-4d39-b877-8dbcfa832619" />


## Solution Implemented

Added a new `--server-header` option to the `fastapi dev` and `fastapi run` commands, which:

- Is disabled by default (`False`), removing the "Server: uvicorn" header from responses
- When explicitly enabled (`--server-header`), maintains the original behavior

## How to Use

To maintain the original behavior (show the server header):
```bash
fastapi dev --server-header
# or
fastapi run --server-header
```