### PR TITLE
➕ Add optional dependency on `fastapi-cloud-cli`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ dependencies = [
 [project.optional-dependencies]
 standard = [
     "uvicorn[standard] >= 0.15.0",
+    "fastapi-cloud-cli >= 0.1.1",
+]
+standard-no-fastapi-cloud-cli = [
+    "uvicorn[standard] >= 0.15.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "typer >= 0.12.3",
+    "typer >= 0.15.1",
     "uvicorn[standard] >= 0.15.0",
-    "rich-toolkit >= 0.11.1"
+    "rich-toolkit >= 0.14.8",
 ]
 
 [project.optional-dependencies]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
--e .
+-e .[standard]
 
 pytest >=4.4.0,<9.0.0
 coverage[toml] >=6.2,<8.0

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover
 
 
 try:
-    from fastapi_cloud_cli.cli import (  # type: ignore[import-not-found]
+    from fastapi_cloud_cli.cli import (
         app as fastapi_cloud_cli,
     )
 

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -25,6 +25,16 @@ except ImportError:  # pragma: no cover
     uvicorn = None  # type: ignore[assignment]
 
 
+try:
+    from fastapi_cloud_cli.cli import (  # type: ignore[import-not-found]
+        app as fastapi_cloud_cli,
+    )
+
+    app.add_typer(fastapi_cloud_cli)
+except ImportError:  # pragma: no cover
+    pass
+
+
 def version_callback(value: bool) -> None:
     if value:
         print(f"FastAPI CLI version: [green]{__version__}[/green]")


### PR DESCRIPTION
➕ Add optional dependency on `fastapi-cloud-cli`

---

When installing `fastapi-cli[standard]` it contains the default standard packages, now including `fastapi-cloud-cli`.

To install all the standard packages minus the `fastapi-cloud-cli` you can install `fastapi-cli[standard-no-fastapi-cloud-cli]`.