### PR TITLE
feat: make rich logger optional

### DIFF
--- a/src/fastapi_cli/logging.py
+++ b/src/fastapi_cli/logging.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import Union
 
 from rich.console import Console
@@ -9,17 +10,21 @@ def setup_logging(
     terminal_width: Union[int, None] = None, level: int = logging.INFO
 ) -> None:
     logger = logging.getLogger("fastapi_cli")
-    console = Console(width=terminal_width) if terminal_width else None
-    rich_handler = RichHandler(
-        show_time=False,
-        rich_tracebacks=True,
-        tracebacks_show_locals=True,
-        markup=True,
-        show_path=False,
-        console=console,
-    )
-    rich_handler.setFormatter(logging.Formatter("%(message)s"))
-    logger.addHandler(rich_handler)
+    if sys.stdout.isatty():
+        # This is a real terminal, use ANSI escape sequences for colored output
+        console = Console(width=terminal_width) if terminal_width else None
+        rich_handler = RichHandler(
+            show_time=False,
+            rich_tracebacks=True,
+            tracebacks_show_locals=True,
+            markup=True,
+            show_path=False,
+            console=console,
+        )
+        rich_handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.propagate = False
+    else:
+        # You're being piped or redirected - pass it to the root logger
+        pass
 
     logger.setLevel(level)
-    logger.propagate = False


### PR DESCRIPTION
Do NOT use rich logger when fastapi cli output is redirected or piped.
For the output to a terminal the behavior is unchanged.

