### PR TITLE
🔧 Remove command script `fastapi`, let it be provided by the `fastapi` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ Repository = "https://github.com/fastapi/fastapi-cli"
 Issues = "https://github.com/fastapi/fastapi-cli/issues"
 Changelog = "https://github.com/fastapi/fastapi-cli/blob/main/release-notes.md"
 
-[project.scripts]
-fastapi = "fastapi_cli.cli:main"
-
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"


### PR DESCRIPTION
🔧 Remove command script (entrypoint) fastapi, let it be provided by the fastapi package

Currently both `fastapi-cli` and `fastapi` provide a command `fastapi`.

The one in `fastapi` checks if `fastapi-cli` (this package) is installed and uses it. And if there's no `fastapi-cli` it tells the user that to use that command they need to install `fastapi-cli`. This is to improve the developer experience, if a user installs only `fastapi` and try to use the `fastapi` command, they would see an error from their shell of "command not found" or similar, not giving them any clue that they need to also install `fastapi-cli`, or better, install `"fastapi[standard]"`.

But then, the functionality is really provided by `fastapi-cli`, so it also declared the same command `fastapi`.

This means that both the `fastapi` and `fastapi-cli` declare the same command, and one would override the other. Here, that override it wouldn't be a problem as in the end it's the same functionality from `fastapi-cli` the one that would be accessed.

And that behavior is, although weird, accepted in Python, mainly because `pip` (and other tools) can just override one command with the other.

Nevertheless, it's problematic for Linux distributions and others that re-pack the packages to be installed as part of distro packages, and those don't support overwriting commands as here.

...plus, it's still weird and strange that two packages declare the same command and would overwrite each other, not even in a deterministic way, it's not even obvious the command of which package would be the one that ends up installed. :sweat_smile: 

Having in mind the developer experience, I'm leaving the command declared in `fastapi`, and removing it from `fastapi-cli`.

It's also not very probable that someone would install only `fastapi-cli`, there's no reason to do it, so this should be a better default.