### PR TITLE
fix: prevent uvicorn log duplication by disabling propagation

### DIFF
--- a/src/fastapi_cli/utils/cli.py
+++ b/src/fastapi_cli/utils/cli.py
@@ -43,7 +43,7 @@ def get_uvicorn_log_config() -> Dict[str, Any]:
             },
         },
         "loggers": {
-            "uvicorn": {"handlers": ["default"], "level": "INFO"},
+            "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
             "uvicorn.error": {"level": "INFO"},
             "uvicorn.access": {
                 "handlers": ["access"],

--- a/tests/test_utils_cli.py
+++ b/tests/test_utils_cli.py
@@ -10,6 +10,7 @@ def test_get_uvicorn_config_uses_custom_formatter() -> None:
 
     assert config["formatters"]["default"]["()"] is CustomFormatter
     assert config["formatters"]["access"]["()"] is CustomFormatter
+    assert config["loggers"]["uvicorn"]["propagate"] is False
 
 
 def test_custom_formatter() -> None:


### PR DESCRIPTION
Uvicorn logs were being duplicated in the application output because they were being processed by both the uvicorn logger and propagated to parent loggers.
