### PR TITLE
✨ Include the version of `fastapi-cloud-cli` to the output of `--version`

### DIFF
--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -51,6 +51,15 @@ except ImportError:  # pragma: no cover
 def version_callback(value: bool) -> None:
     if value:
         print(f"FastAPI CLI version: [green]{__version__}[/green]")
+        try:
+            from fastapi_cloud_cli import (
+                __version__ as cloud_cli_version,
+            )
+
+            print(f"FastAPI Cloud CLI version: [green]{cloud_cli_version}[/green]")
+        except ImportError:  # pragma: no cover
+            pass
+
         raise typer.Exit()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -452,6 +452,7 @@ def test_version() -> None:
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0, result.output
     assert "FastAPI CLI version:" in result.output
+    assert "FastAPI Cloud CLI version:" in result.output
 
 
 def test_dev_reload_dir() -> None:


### PR DESCRIPTION
With `fastapi-cloud-cli` installed:

```console
$ fastapi --version

FastAPI CLI version: 0.0.24
FastAPI Cloud CLI version: 0.15.0
```

Without `fastapi-cloud-cli` installed:
```console
$ fastapi --version

FastAPI CLI version: 0.0.24
```

---

We may also want to support `fastapi cloud --version`, I opened PR https://github.com/fastapilabs/fastapi-cloud-cli/pull/168 for this 

