### PR TITLE
🚸 Show tip on how to configure `entrypoint` in `pyproject.toml`

### DIFF
--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 import typer
 from pydantic import ValidationError
 from rich import print
+from rich.syntax import Syntax
 from rich.tree import Tree
 
 from fastapi_cli.config import FastAPIConfig
@@ -214,6 +215,24 @@ def _run(
         else:
             toolkit.print(f" • Module: {mod_source_desc}")
             toolkit.print(f" • App name: {app_source_desc}")
+
+        if import_data.module_config_source == "auto-discovery":
+            toolkit.print_line()
+            toolkit.print(
+                "You can configure an entrypoint in pyproject.toml for this app with:",
+                tag="tip",
+            )
+            toolkit.print_line()
+            toolkit.print(
+                Syntax(
+                    (
+                        "[tool.fastapi]\n"
+                        f'entrypoint = "{import_data.module_data.module_import_str}:{import_data.app_name}"'
+                    ),
+                    "toml",
+                    theme="ansi_light",
+                )
+            )
 
         url = f"http://{host}:{port}"
         url_docs = f"{url}/docs"

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -219,7 +219,7 @@ def _run(
         if import_data.module_config_source == "auto-discovery":
             toolkit.print_line()
             toolkit.print(
-                "You can configure an entrypoint in pyproject.toml for this app with:",
+                "You can configure an entrypoint in [blue]pyproject.toml[/] for this app with:",
                 tag="tip",
             )
             toolkit.print_line()

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -228,7 +228,7 @@ def _run(
         if import_data.module_config_source == "auto-discovery":
             toolkit.print_line()
             toolkit.print(
-                "You can configure an entrypoint in pyproject.toml for this app with:",
+                "You can configure an entrypoint in [blue]pyproject.toml[/] for this app with:",
                 tag="tip",
             )
             toolkit.print_line()

--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 import typer
 from pydantic import ValidationError
 from rich import print
+from rich.syntax import Syntax
 from rich.tree import Tree
 
 from fastapi_cli.config import FastAPIConfig
@@ -223,6 +224,24 @@ def _run(
         else:
             toolkit.print(f" • Module: {mod_source_desc}")
             toolkit.print(f" • App name: {app_source_desc}")
+
+        if import_data.module_config_source == "auto-discovery":
+            toolkit.print_line()
+            toolkit.print(
+                "You can configure an entrypoint in pyproject.toml for this app with:",
+                tag="tip",
+            )
+            toolkit.print_line()
+            toolkit.print(
+                Syntax(
+                    (
+                        "[tool.fastapi]\n"
+                        f'entrypoint = "{import_data.module_data.module_import_str}:{import_data.app_name}"'
+                    ),
+                    "toml",
+                    theme="ansi_light",
+                )
+            )
 
         url = f"http://{host}:{port}"
         url_docs = f"{url}/docs"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def test_dev() -> None:
         assert "Configuration sources:" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8000" in result.output
         assert "Documentation at http://127.0.0.1:8000/docs" in result.output
@@ -64,6 +65,9 @@ def test_dev_no_args_auto_discovery() -> None:
         assert "Using import string: main:app" in result.output
         assert "Configuration sources:" in result.output
         assert "Import string: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" in result.output
+        assert "[tool.fastapi]" in result.output
+        assert 'entrypoint = "main:app"' in result.output
 
 
 def test_dev_package() -> None:
@@ -88,6 +92,7 @@ def test_dev_package() -> None:
         assert "Using import string: nested_package.package:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8000" in result.output
         assert "Documentation at http://127.0.0.1:8000/docs" in result.output
@@ -140,6 +145,7 @@ def test_dev_args() -> None:
         assert "Using import string: single_file_app:api" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: --app CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://192.168.0.2:8080" in result.output
         assert "Documentation at http://192.168.0.2:8080/docs" in result.output
@@ -173,6 +179,7 @@ def test_dev_env_vars() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8111" in result.output
         assert "Documentation at http://127.0.0.1:8111/docs" in result.output
@@ -213,6 +220,7 @@ def test_dev_env_vars_and_args() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8080" in result.output
         assert "Documentation at http://127.0.0.1:8080/docs" in result.output
@@ -261,6 +269,7 @@ def test_run() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://0.0.0.0:8000" in result.output
         assert "Documentation at http://0.0.0.0:8000/docs" in result.output
@@ -338,6 +347,7 @@ def test_run_args() -> None:
         assert "Using import string: single_file_app:api" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: --app CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://192.168.0.2:8080" in result.output
         assert "Documentation at http://192.168.0.2:8080/docs" in result.output
@@ -371,6 +381,7 @@ def test_run_env_vars() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://0.0.0.0:8111" in result.output
         assert "Documentation at http://0.0.0.0:8111/docs" in result.output
@@ -407,6 +418,7 @@ def test_run_env_vars_and_args() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://0.0.0.0:8080" in result.output
         assert "Documentation at http://0.0.0.0:8080/docs" in result.output
@@ -520,6 +532,7 @@ def test_dev_with_import_string() -> None:
             }
         assert "Using import string: single_file_app:api" in result.output
         assert "Import string: --entrypoint CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
 
 
 def test_run_with_import_string() -> None:
@@ -543,6 +556,7 @@ def test_run_with_import_string() -> None:
             }
         assert "Using import string: single_file_app:app" in result.output
         assert "Import string: --entrypoint CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
 
 
 def test_script() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def test_dev() -> None:
         assert "Configuration sources:" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8000" in result.output
         assert "Documentation at http://127.0.0.1:8000/docs" in result.output
@@ -64,6 +65,9 @@ def test_dev_no_args_auto_discovery() -> None:
         assert "Using import string: main:app" in result.output
         assert "Configuration sources:" in result.output
         assert "Import string: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" in result.output
+        assert "[tool.fastapi]" in result.output
+        assert 'entrypoint = "main:app"' in result.output
 
 
 def test_dev_package() -> None:
@@ -88,6 +92,7 @@ def test_dev_package() -> None:
         assert "Using import string: nested_package.package:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8000" in result.output
         assert "Documentation at http://127.0.0.1:8000/docs" in result.output
@@ -140,6 +145,7 @@ def test_dev_args() -> None:
         assert "Using import string: single_file_app:api" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: --app CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://192.168.0.2:8080" in result.output
         assert "Documentation at http://192.168.0.2:8080/docs" in result.output
@@ -173,6 +179,7 @@ def test_dev_env_vars() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8111" in result.output
         assert "Documentation at http://127.0.0.1:8111/docs" in result.output
@@ -213,6 +220,7 @@ def test_dev_env_vars_and_args() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting development server 🚀" in result.output
         assert "Server started at http://127.0.0.1:8080" in result.output
         assert "Documentation at http://127.0.0.1:8080/docs" in result.output
@@ -261,6 +269,7 @@ def test_run() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://0.0.0.0:8000" in result.output
         assert "Documentation at http://0.0.0.0:8000/docs" in result.output
@@ -338,6 +347,7 @@ def test_run_args() -> None:
         assert "Using import string: single_file_app:api" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: --app CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://192.168.0.2:8080" in result.output
         assert "Documentation at http://192.168.0.2:8080/docs" in result.output
@@ -371,6 +381,7 @@ def test_run_env_vars() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://0.0.0.0:8111" in result.output
         assert "Documentation at http://0.0.0.0:8111/docs" in result.output
@@ -407,6 +418,7 @@ def test_run_env_vars_and_args() -> None:
         assert "Using import string: single_file_app:app" in result.output
         assert "Module: path CLI argument" in result.output
         assert "App name: auto-discovery" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
         assert "Starting production server 🚀" in result.output
         assert "Server started at http://0.0.0.0:8080" in result.output
         assert "Documentation at http://0.0.0.0:8080/docs" in result.output
@@ -521,6 +533,7 @@ def test_dev_with_import_string() -> None:
             }
         assert "Using import string: single_file_app:api" in result.output
         assert "Import string: --entrypoint CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
 
 
 def test_run_with_import_string() -> None:
@@ -544,6 +557,7 @@ def test_run_with_import_string() -> None:
             }
         assert "Using import string: single_file_app:app" in result.output
         assert "Import string: --entrypoint CLI option" in result.output
+        assert "You can configure an entrypoint in pyproject.toml" not in result.output
 
 
 def test_script() -> None:


### PR DESCRIPTION
When neither `path` argument nor `--entrypoint` option are specified, show a tip on how to configure `entrypoint` in `pyproject.toml`.

---

<img width="663" height="224" alt="image" src="https://github.com/user-attachments/assets/59c9f613-1635-4334-b3ba-501789e8b7ed" />

---

<img width="754" height="361" alt="image" src="https://github.com/user-attachments/assets/22ddc95d-93aa-4faa-9fbb-9ebf9829b10f" />


