### PR TITLE
👷 Add pre-commit hook to catch typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,11 @@ repos:
         -   --unsafe
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/crate-ci/typos
+    rev: bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0
+    hooks:
+    -   id: typos
+        args: [--force-exclude]
 -   repo: local
     hooks:
       - id: local-ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,6 @@ error-on-warning = true
 extend-exclude = [
     "coverage/",
     "dist/",
-    "docs/img/",
     "release-notes.md",
     "htmlcov/",
     "uv.lock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,3 +161,16 @@ keep-runtime-typing = true
 
 [tool.ty.terminal]
 error-on-warning = true
+
+[tool.typos.files]
+extend-exclude = [
+    "coverage/",
+    "dist/",
+    "docs/img/",
+    "release-notes.md",
+    "htmlcov/",
+    "uv.lock",
+]
+
+[tool.typos.default.extend-identifiers]
+alls = "alls"


### PR DESCRIPTION
Set up pre-commit hook to catch typos in sources.
Same as in https://github.com/fastapi/fastapi/pull/15482

No typos currently found by `prek run typos --all-files`