### PR TITLE
📝 Update docs badges: remove Publish badge, it doesn't give extra information

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 <a href="https://github.com/fastapi/fastapi-cli/actions/workflows/test.yml" target="_blank">
     <img src="https://github.com/fastapi/fastapi-cli/actions/workflows/test.yml/badge.svg" alt="Test">
 </a>
-<a href="https://github.com/fastapi/fastapi-cli/actions/workflows/publish.yml" target="_blank">
-</a>
 <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi-cli" target="_blank">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/fastapi-cli.svg" alt="Coverage">
 <a href="https://pypi.org/project/fastapi-cli" target="_blank">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
     <img src="https://github.com/fastapi/fastapi-cli/actions/workflows/test.yml/badge.svg" alt="Test">
 </a>
 <a href="https://github.com/fastapi/fastapi-cli/actions/workflows/publish.yml" target="_blank">
-    <img src="https://github.com/fastapi/fastapi-cli/actions/workflows/publish.yml/badge.svg" alt="Publish">
 </a>
 <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi-cli" target="_blank">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/fastapi-cli.svg" alt="Coverage">


### PR DESCRIPTION
## Summary
- Remove the Publish workflow badge from the docs badges.
- Keep the remaining status, coverage, and package badges unchanged.

## AI Disclaimer
Codex GPT 5.5, reviewed by hand.
