### PR TITLE
🐛 Avoid fancy logs for non-TTY output

### DIFF
--- a/src/fastapi_cli/cli.py
+++ b/src/fastapi_cli/cli.py
@@ -20,7 +20,11 @@ from fastapi_cli.exceptions import FastAPICLIException
 
 from . import __version__
 from .logging import setup_logging
-from .utils.cli import get_rich_toolkit, get_uvicorn_log_config
+from .utils.cli import (
+    get_rich_toolkit,
+    get_uvicorn_log_config,
+    should_use_rich_logs,
+)
 
 app = typer.Typer(
     rich_markup_mode="rich", context_settings={"help_option_names": ["-h", "--help"]}
@@ -271,6 +275,10 @@ def _run(
         toolkit.print("Logs:")
         toolkit.print_line()
 
+        extra_uvicorn_kwargs: dict[str, Any] = (
+            {"log_config": get_uvicorn_log_config()} if should_use_rich_logs() else {}
+        )
+
         uvicorn.run(
             app=import_string,
             host=host,
@@ -285,7 +293,7 @@ def _run(
             root_path=root_path,
             proxy_headers=proxy_headers,
             forwarded_allow_ips=forwarded_allow_ips,
-            log_config=get_uvicorn_log_config(),
+            **extra_uvicorn_kwargs,
         )
 
 

--- a/src/fastapi_cli/utils/cli.py
+++ b/src/fastapi_cli/utils/cli.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import Any
 
 from rich_toolkit import RichToolkit, RichToolkitTheme
@@ -18,6 +19,11 @@ class CustomFormatter(DefaultFormatter):
         if message == "Shutting down":
             result = "\n" + result
         return result
+
+
+def should_use_rich_logs() -> bool:
+    """Return True when stdout is a TTY and rich logs should be used, False otherwise."""
+    return sys.stdout.isatty()
 
 
 def get_uvicorn_log_config() -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,11 @@ runner = CliRunner()
 assets_path = Path(__file__).parent / "assets"
 
 
+@pytest.fixture(autouse=True)
+def force_rich_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("fastapi_cli.cli.should_use_rich_logs", lambda: True)
+
+
 def test_dev() -> None:
     with changing_dir(assets_path):
         with patch.object(uvicorn, "run") as mock_run:
@@ -49,6 +54,21 @@ def test_dev() -> None:
         )
 
         assert "🐍 single_file_app.py" in result.output
+
+
+def test_run_uses_uvicorn_default_log_config_without_rich_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("fastapi_cli.cli.should_use_rich_logs", lambda: False)
+
+    with changing_dir(assets_path):
+        with patch.object(uvicorn, "run") as mock_run:
+            result = runner.invoke(app, ["run", "single_file_app.py"])
+            assert result.exit_code == 0, result.output
+            assert mock_run.called
+            assert mock_run.call_args
+
+    assert "log_config" not in mock_run.call_args.kwargs
 
 
 def test_dev_no_args_auto_discovery() -> None:

--- a/tests/test_utils_cli.py
+++ b/tests/test_utils_cli.py
@@ -1,9 +1,15 @@
+import io
 import logging
+import sys
 from logging.config import dictConfig
 
-from pytest import LogCaptureFixture
+from pytest import LogCaptureFixture, MonkeyPatch
 
-from fastapi_cli.utils.cli import CustomFormatter, get_uvicorn_log_config
+from fastapi_cli.utils.cli import (
+    CustomFormatter,
+    get_uvicorn_log_config,
+    should_use_rich_logs,
+)
 
 
 def test_get_uvicorn_config_uses_custom_formatter() -> None:
@@ -12,6 +18,14 @@ def test_get_uvicorn_config_uses_custom_formatter() -> None:
     assert config["formatters"]["default"]["()"] is CustomFormatter
     assert config["formatters"]["access"]["()"] is CustomFormatter
     assert config["loggers"]["uvicorn"]["propagate"] is False
+
+
+def test_should_use_rich_logs_is_false_without_tty(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+    assert should_use_rich_logs() is False
 
 
 def test_custom_formatter() -> None:


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #458 (`2026-07-03-use-minimal-startup-output-outside-tty`)
- #463 (`2026-07-07-bring-the-full-fastapi-style-for-sharing-with-fast`)
- **#457** (`2026-07-03-avoid-fancy-logs-for-non-tty-output`) <-- this PR
<!-- shortcake:end -->