### PR TITLE
Remove redundant uvicorn[standard] from optional-dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 standard = [
-    "uvicorn[standard] >= 0.15.0",
-    "fastapi-cloud-cli >= 0.1.1",
+    "fastapi-cloud-cli >= 0.1.1"
 ]
 standard-no-fastapi-cloud-cli = [
     "uvicorn[standard] >= 0.15.0",


### PR DESCRIPTION
Removes the redundant `uvicorn[standard] >= 0.15.0` entry from
`[project.optional-dependencies].standard` in pyproject.toml.

`uvicorn[standard]` is already a mandatory dependency (listed under
`dependencies`), so listing it again under the optional "standard" group
is redundant and can mislead readers into thinking it's only installed
when the optional extra is requested.

Follow-up to the remaining item raised in
https://github.com/fastapi/fastapi-cli/discussions/171

## AI Disclaimer

Used Claude (Anthropic) to help understand the pyproject.toml structure
(dependencies vs optional-dependencies) , since this is my first open source
contribution. The actual identification of the issue was already
reported by @BhuwanPandey in the linked discussion; my contribution is
just implementing the one-line fix.

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.