### PR TITLE
⬆️ Bump Typer min version to `0.26.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "typer >= 0.16.0",
+    "typer >= 0.26.1",
     "uvicorn[standard] >= 0.15.0",
     "rich-toolkit >= 0.14.8",
     "tomli >= 2.0.0; python_version < '3.11'"

--- a/uv.lock
+++ b/uv.lock
@@ -327,7 +327,7 @@ requires-dist = [
     { name = "fastapi-new", marker = "extra == 'new'", specifier = ">=0.0.2" },
     { name = "rich-toolkit", specifier = ">=0.14.8" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
-    { name = "typer", specifier = ">=0.16.0" },
+    { name = "typer", specifier = ">=0.26.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.15.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'standard'", specifier = ">=0.15.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'standard-no-fastapi-cloud-cli'", specifier = ">=0.15.0" },


### PR DESCRIPTION
Tests in CI are currently failing with uv resolution `lowest-direct`. Bumping min Typer version to 0.26.0 to resolve this

🤖 This pull request was created with the help of AI (Codex).

Checked manually